### PR TITLE
Fix snake workflow branch push bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,14 +37,6 @@ jobs:
      # show the status of the build. Makes it easier for debugging (if there's any issues).
       - run: git status
 
-      # Push the changes
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: master
-          force: true
-
       - uses: crazy-max/ghaction-github-pages@v2.1.3
         with:
           # the output branch we mentioned above


### PR DESCRIPTION
### Motivation
- The scheduled workflow was force-pushing generated assets to `master`, which contradicts the inline comment that assets should go to an `output` branch and risks overwriting the default branch.

### Description
- Removed the `ad-m/github-push-action@master` step that was force-pushing artifacts to `master` and its `branch: master`/`force: true` configuration.
- Kept the `Platane/snk@master` step that generates `dist/github-contribution-grid-snake.gif` and `dist/github-contribution-grid-snake.svg` and retained the `crazy-max/ghaction-github-pages@v2.1.3` deployment to the `output` branch with `build_dir: dist`.

### Testing
- Parsed `.github/workflows/main.yml` using Ruby (`YAML.load_file`) which returned `OK` indicating valid YAML syntax.
- Attempted a Python `yaml.safe_load` check which failed due to a missing `PyYAML` dependency, but the Ruby validation confirmed the workflow file is syntactically valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e79090cb54832d84bf567c70763df0)